### PR TITLE
Compile in release mode only when build is in release mode

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -67,20 +67,26 @@ impl Builder {
 
         let mut xargo = ExecutableRunner::new(Xargo);
 
+        let mut args = Vec::new();
+
+        args.push("build");
+
+        let profile = env::var("PROFILE");
+        if !profile.is_ok() || profile.unwrap() == "release" {
+            args.push("--release");
+        }
+
+        args.push("--color");
+        args.push(match self.colors {
+            true => "always",
+            false => "never",
+        });
+
+        args.push("--target");
+        args.push(self.target.get_target_name());
+
         xargo
-            .with_args(&[
-                "build",
-                "--release",
-                "--color",
-                {
-                    match self.colors {
-                        true => "always",
-                        false => "never",
-                    }
-                },
-                "--target",
-                self.target.get_target_name(),
-            ])
+            .with_args(&args)
             .with_cwd(proxy.get_path())
             .with_env("PTX_CRATE_BUILDING", "1")
             .with_env("CARGO_TARGET_DIR", proxy.get_output_path())

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -19,10 +19,8 @@ lazy_static! {
 #[test]
 fn should_provide_output_path() {
     let project = Project::analyze("tests/fixtures/sample-crate").unwrap();
-    let mut builder = {
-        let _lock = ENV_MUTEX.lock().unwrap();
-        Builder::new("tests/fixtures/sample-crate").unwrap()
-    };
+    let _lock = ENV_MUTEX.lock().unwrap();
+    let mut builder = Builder::new("tests/fixtures/sample-crate").unwrap();
 
     match builder.build().unwrap() {
         BuildStatus::Success(output) => {
@@ -45,10 +43,34 @@ fn should_write_assembly() {
     let project = Project::analyze("tests/fixtures/sample-crate").unwrap();
     remove_dir_all(project.get_proxy_crate().unwrap().get_output_path()).unwrap_or_default();
 
-    let mut builder = {
-        let _lock = ENV_MUTEX.lock().unwrap();
-        Builder::new("tests/fixtures/sample-crate").unwrap()
-    };
+    let _lock = ENV_MUTEX.lock().unwrap();
+    let mut builder = Builder::new("tests/fixtures/sample-crate").unwrap();
+
+    match builder.build().unwrap() {
+        BuildStatus::Success(output) => {
+            let mut assembly_contents = String::new();
+
+            File::open(output.get_assembly_path())
+                .unwrap()
+                .read_to_string(&mut assembly_contents)
+                .unwrap();
+
+            assert!(assembly_contents.contains(".visible .entry the_kernel("));
+        }
+
+        BuildStatus::NotNeeded => unreachable!(),
+    }
+}
+
+#[test]
+fn should_write_assembly_in_debug_mode() {
+    let project = Project::analyze("tests/fixtures/sample-crate").unwrap();
+    remove_dir_all(project.get_proxy_crate().unwrap().get_output_path()).unwrap_or_default();
+
+    let _lock = ENV_MUTEX.lock().unwrap();
+    let mut builder = Builder::new("tests/fixtures/sample-crate").unwrap();
+
+    env::set_var("PROFILE", "debug");
 
     match builder.build().unwrap() {
         BuildStatus::Success(output) => {
@@ -68,10 +90,8 @@ fn should_write_assembly() {
 
 #[test]
 fn should_report_about_build_failure() {
-    let mut builder = {
-        let _lock = ENV_MUTEX.lock().unwrap();
-        Builder::new("tests/fixtures/faulty-crate").unwrap()
-    };
+    let _lock = ENV_MUTEX.lock().unwrap();
+    let mut builder = Builder::new("tests/fixtures/faulty-crate").unwrap();
 
     let output = builder.disable_colors().build();
     let crate_absoulte_path = current_dir().unwrap().join("tests/fixtures/faulty-crate");
@@ -118,10 +138,8 @@ fn should_report_about_build_failure() {
 
 #[test]
 fn should_provide_crate_source_files() {
-    let mut builder = {
-        let _lock = ENV_MUTEX.lock().unwrap();
-        Builder::new("tests/fixtures/sample-crate").unwrap()
-    };
+    let _lock = ENV_MUTEX.lock().unwrap();
+    let mut builder = Builder::new("tests/fixtures/sample-crate").unwrap();
 
     match builder.build().unwrap() {
         BuildStatus::Success(output) => {


### PR DESCRIPTION
Fixes #5 
I feel like the intent is right, but I'm getting a bad-looking error from `xargo` when it tries to compile without the `--release` flag:

```
   Compiling sample-ptx_crate v0.1.0 (file://$HOME/Dropbox/Programming/rust/rust-ptx-builder/tests/fixtures/sample-crate)
   Compiling proxy v0.0.0 (file:///tmp/ptx-builder/sample_ptx_crate/2173c7eb610022fa)
error: linking with `ptx-linker` failed: exit code: 1
  |
  = note: "ptx-linker" "-L" "$HOME/.xargo/lib/rustlib/nvptx64-nvidia-cuda/lib" "/tmp/ptx-builder/sample_ptx_crate/2173c7eb610022fa/target/nvptx64-nvidia-cuda/debug/deps/proxy.3rg6oty3sxxix4x5.rcgu.o" "-o" "/tmp/ptx-builder/sample_ptx_crate/2173c7eb610022fa/target/nvptx64-nvidia-cuda/debug/deps/proxy.ptx" "/tmp/ptx-builder/sample_ptx_crate/2173c7eb610022fa/target/nvptx64-nvidia-cuda/debug/deps/proxy.crate.metadata.rcgu.o" "-L" "/tmp/ptx-builder/sample_ptx_crate/2173c7eb610022fa/target/nvptx64-nvidia-cuda/debug/deps" "-L" "/tmp/ptx-builder/sample_ptx_crate/2173c7eb610022fa/target/debug/deps" "-L" "$HOME/.xargo/lib/rustlib/nvptx64-nvidia-cuda/lib" "-Bstatic" "--whole-archive" "/tmp/rustc.9Iv8OM6g45O1/libsample_ptx_crate-832f87e79ce5cf64.rlib" "--no-whole-archive" "--whole-archive" "/tmp/rustc.9Iv8OM6g45O1/libcore-d30d934963d2f831.rlib" "--no-whole-archive" "/tmp/rustc.9Iv8OM6g45O1/libcompiler_builtins-75beea7828105c3b.rlib" "-shared" "-Bdynamic"
  = note:  [INFO] Going to link 2 bitcode modules and 3 rlibs...
                  
          [DEBUG] Linking bitcode: "/tmp/ptx-builder/sample_ptx_crate/2173c7eb610022fa/target/nvptx64-nvidia-cuda/debug/deps/proxy.3rg6oty3sxxix4x5.rcgu.o"
          error: Invalid record
          

error: aborting due to previous error

error: Could not compile `proxy`.

To learn more, run the command again with --verbose.
```

Any idea how to solve that?